### PR TITLE
Add Sprite to char* JPEG Drawing

### DIFF
--- a/TFT_eFEX.cpp
+++ b/TFT_eFEX.cpp
@@ -360,8 +360,9 @@ void TFT_eFEX::drawJpeg(String filename, int16_t xpos, int16_t ypos, TFT_eSprite
 ** Function name:           drawJpeg
 ** Description:             draw a jpeg stored in FLASH onto the TFT
 ***************************************************************************************/
-void TFT_eFEX::drawJpeg(const uint8_t arrayname[], uint32_t array_size, int16_t xpos, int16_t ypos) {
+void TFT_eFEX::drawJpeg(const uint8_t arrayname[], uint32_t array_size, int16_t xpos, int16_t ypos, TFT_eSprite *_spr) {
 
+  if ( (_spr == nullptr) && ((xpos >= _tft->width()) || (ypos >= _tft->height()))) return;
   boolean decoded = JpegDec.decodeArray(arrayname, array_size);
 
   if (decoded) {
@@ -429,7 +430,8 @@ void TFT_eFEX::drawJpeg(const uint8_t arrayname[], uint32_t array_size, int16_t 
           }
         }
 
-        _tft->pushImage(mcu_x, mcu_y, win_w, win_h, pImg);
+        if (_spr == nullptr)  _tft->pushImage(mcu_x, mcu_y, win_w, win_h, pImg);
+        else _spr->pushImage(mcu_x, mcu_y, win_w, win_h, pImg);
       }
       else
       {

--- a/TFT_eFEX.h
+++ b/TFT_eFEX.h
@@ -78,7 +78,7 @@ class TFT_eFEX : public TFT_eSPI {
   void     drawJpeg(String filename, int16_t xpos, int16_t ypos, TFT_eSprite *_spr = nullptr);
 
            // Draw a Jpeg stored in a program memory array to the TFT (uses JPEGDecoder library)
-  void     drawJpeg(const uint8_t arrayname[], uint32_t array_size, int16_t xpos, int16_t ypos);
+  void     drawJpeg(const uint8_t arrayname[], uint32_t array_size, int16_t xpos, int16_t ypos, TFT_eSprite *_spr = nullptr);
 
            // List information about a Jpeg file to the Serial port (uses JPEGDecoder library)
   void     jpegInfo(String filename);


### PR DESCRIPTION
Hey,

I'm in a scenario where I draw a lot of images and SPIFFS based loading is just too slow.
I couldn't find a way to draw PROGMEM based image arrays to sprites, so I took the liberty of adding that. I hope thats ok otherwise let me know what to fixup.

-----

Extend the drawJpeg for PROGMEM Images by an optional
sprite pointer using much of the same code from the
SPIFFS based one.