### PR TITLE
Init fix and performance improvement

### DIFF
--- a/TFT_eFEX.cpp
+++ b/TFT_eFEX.cpp
@@ -1113,7 +1113,6 @@ void TFT_eFEX::drawGradientLine( int32_t x0, int32_t y0, int32_t x1, int32_t y1,
   int32_t err = dx >> 1, ystep = -1, xs = x0, dlen = 0;
 
   if (y0 < y1) ystep = 1;
-
   // Split into steep and not steep for H/V separation
   if (steep) {
     for (; x0 <= x1; x0++) {
@@ -1131,6 +1130,7 @@ void TFT_eFEX::drawGradientLine( int32_t x0, int32_t y0, int32_t x1, int32_t y1,
         }
         dlen = 0; y0 += ystep; xs = x0 + 1;
       }
+      yield();
     }
     if (dlen) {
        _colorstart = colorAt( _y0, _x0, _y1, _x1, y0, xs, colorstart, colorend );
@@ -1153,6 +1153,7 @@ void TFT_eFEX::drawGradientLine( int32_t x0, int32_t y0, int32_t x1, int32_t y1,
         }
         dlen = 0; y0 += ystep; xs = x0 + 1;
       }
+      yield();
     }
     if (dlen) {
       _colorstart = colorAt( _x0, _y0, _x1, _y1, xs, y0, colorstart, colorend );
@@ -1168,12 +1169,15 @@ void TFT_eFEX::drawGradientHLine( int32_t x, int32_t y, int32_t w, RGBColor colo
   if (x < 0) { w += x; x = 0; }
   if ((x + w) > width())  w = width()  - x;
   if (w < 1) return;
+  _tft->startWrite();
   for( int32_t i = x; i < x+w; i++ ) {
     uint8_t r = map( i, x, x+w, colorstart.r, colorend.r );
     uint8_t g = map( i, x, x+w, colorstart.g, colorend.g );
     uint8_t b = map( i, x, x+w, colorstart.b, colorend.b );
     _tft->drawPixel( i, y, _tft->color565( r, g, b ) );
+    yield();
   }
+  _tft->endWrite();
 }
 
 
@@ -1182,12 +1186,15 @@ void TFT_eFEX::drawGradientVLine( int32_t x, int32_t y, int32_t h, RGBColor colo
   if ( y < 0 ) { h += y; y = 0; }
   if ( (y + h) > height() ) h = height() - y;
   if ( h < 1 ) return;
+  _tft->startWrite();
   for( int32_t i = y; i < y+h; i++ ) {
     uint8_t r = map( i, y, y+h, colorstart.r, colorend.r );
     uint8_t g = map( i, y, y+h, colorstart.g, colorend.g );
     uint8_t b = map( i, y, y+h, colorstart.b, colorend.b );
     _tft->drawPixel( x, i, _tft->color565( r, g, b ) );
+    yield();
   }
+  _tft->endWrite();
 }
 
 

--- a/examples/LineGradients/LineGradients.ino
+++ b/examples/LineGradients/LineGradients.ino
@@ -11,18 +11,6 @@ TFT_eSPI tft = TFT_eSPI();       // Create object "tft"
 TFT_eFEX  fex = TFT_eFEX(&tft);    // Create TFT_eFEX object "fex" with pointer to "tft" object
 
 
-RGBColor colorstart;
-RGBColor colorend;
-uint8_t margin = 50;
-uint16_t boxw = (tft.width()/2)-margin;
-uint16_t boxh = (tft.height()/2)-margin;
-uint16_t centerx = tft.width()/2;
-uint16_t centery = tft.height()/2;
-uint16_t xpos = 50;
-uint16_t ypos = 50;
-byte r = 25;
-
-
 void randomColors( RGBColor &colorstart, RGBColor &colorend ) {
   colorstart = { 128, byte(random(128)), byte(random(128)) }; // create some random color
   colorend = { byte(random(128)+127), 255, byte(random(128)+127) }; // create some random color
@@ -104,6 +92,18 @@ void setup(void) {
 
 // =========================================================================
 void loop() {
+
+  RGBColor colorstart;
+  RGBColor colorend;
+  uint8_t margin = 50;
+  uint16_t boxw = (tft.width()/2)-margin;
+  uint16_t boxh = (tft.height()/2)-margin;
+  uint16_t centerx = tft.width()/2;
+  uint16_t centery = tft.height()/2;
+  uint16_t xpos = 50;
+  uint16_t ypos = 50;
+  byte r = 25;
+
   tft.fillScreen(TFT_BLACK);
 
   randomColors( colorstart, colorend );


### PR DESCRIPTION
followup for #10 
  - added some yield() and tft.startWrite/endWrite as suggested
  - moved the declarations into the loop for the example
  - found a lame excuse for the moiré
  - made some 8bits tests 

![image](https://user-images.githubusercontent.com/1893754/69891641-4feac300-12fe-11ea-9442-8bf41f1525f6.png)
