### PR TITLE
Use _tft to calculate viewport width/height

### DIFF
--- a/TFT_eFEX.cpp
+++ b/TFT_eFEX.cpp
@@ -1165,9 +1165,9 @@ void TFT_eFEX::drawGradientLine( int32_t x0, int32_t y0, int32_t x1, int32_t y1,
 
 
 void TFT_eFEX::drawGradientHLine( int32_t x, int32_t y, int32_t w, RGBColor colorstart, RGBColor colorend ) {
-  if ((y < 0) || (x >= width()) || (y >= height())) return;
+  if ((y < 0) || (x >= _tft->width()) || (y >= height())) return;
   if (x < 0) { w += x; x = 0; }
-  if ((x + w) > width())  w = width()  - x;
+  if ((x + w) > _tft->width())  w = _tft->width()  - x;
   if (w < 1) return;
   _tft->startWrite();
   for( int32_t i = x; i < x+w; i++ ) {
@@ -1182,9 +1182,9 @@ void TFT_eFEX::drawGradientHLine( int32_t x, int32_t y, int32_t w, RGBColor colo
 
 
 void TFT_eFEX::drawGradientVLine( int32_t x, int32_t y, int32_t h, RGBColor colorstart, RGBColor colorend ) {
-  if ( ( x < 0 ) || ( x >= width() ) || ( y >= height() ) ) return;
+  if ( ( x < 0 ) || ( x >= _tft->width() ) || ( y >= _tft->height() ) ) return;
   if ( y < 0 ) { h += y; y = 0; }
-  if ( (y + h) > height() ) h = height() - y;
+  if ( (y + h) > _tft->height() ) h = _tft->height() - y;
   if ( h < 1 ) return;
   _tft->startWrite();
   for( int32_t i = y; i < y+h; i++ ) {

--- a/TFT_eFEX.cpp
+++ b/TFT_eFEX.cpp
@@ -1165,7 +1165,7 @@ void TFT_eFEX::drawGradientLine( int32_t x0, int32_t y0, int32_t x1, int32_t y1,
 
 
 void TFT_eFEX::drawGradientHLine( int32_t x, int32_t y, int32_t w, RGBColor colorstart, RGBColor colorend ) {
-  if ((y < 0) || (x >= _tft->width()) || (y >= height())) return;
+  if ((y < 0) || (x >= _tft->width()) || (y >= _tft->height())) return;
   if (x < 0) { w += x; x = 0; }
   if ((x + w) > _tft->width())  w = _tft->width()  - x;
   if (w < 1) return;


### PR DESCRIPTION
followup for #13 

thanks for the insight on the user setup, I mostly use Arduino so the best I've come up with is defining pin values before including TFT_eSPI and also defining #USER_SETUP_DONE to prevent further loading of any default setup, but I only found this out after losing a dozen profiles :man_facepalming: 

re: pixels on the small circles, I agree it could be nicer by drawing circles but the example is about demonstrating line gradients, that unperfect disc drawing is there do show the *features* of drawGradientLine, and that includes the limitations of the drawLine algorithm.

In the pie chart example you mention, the fillSegment() function uses fillTriangle().
Problem: fillTriangle() only uses horizontal lines for its rendering and I want to demonstrate gradientLines in all directions
Only one gradient direction is too limitative to make it worth writing a fillGradientTriangle() function, and I don't feel confident enough to create the missing parts.

I'll dig into [this repo](https://github.com/androdlang/TFTShape) to see what I can find but I suspect the optimizations also tend to single direction and prevent code re-use.